### PR TITLE
Acc 533/locking mechanism

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject b-social/event-processor "0.1.0-SNAPSHOT"
+(defproject b-social/event-processor "0.1.1-SNAPSHOT"
 
   :description "A library for processing events as a stuartsierra component and configured with configurati. Opinionated that the event processing will be wrapped in a jdbc transaction."
 
@@ -12,8 +12,7 @@
                  [io.logicblocks/configurati "0.5.2"]
                  [cambium/cambium.core "0.9.3"]
                  [cambium/cambium.codec-cheshire "0.9.3"]
-                 [org.clojure/java.jdbc "0.7.11"]
-                 [com.layerware/hugsql "0.4.9"]]
+                 [org.clojure/java.jdbc "0.7.11"]]
 
   :plugins [[lein-cloverage "1.1.2"]
             [lein-shell "0.5.0"]

--- a/src/event_processor/processor/component.clj
+++ b/src/event_processor/processor/component.clj
@@ -5,7 +5,7 @@
             [event-processor.processor.protocols
              :refer [on-processing-complete
                      get-unprocessed-events group-unprocessed-events-by handle-event]]
-            [event-processor.processor.locking.locks :refer [with-lock get-lock release-lock]]))
+            [event-processor.processor.locking.locks :refer [with-lock]]))
 
 (defn- milliseconds [millis] millis)
 

--- a/src/event_processor/processor/locking/locks.clj
+++ b/src/event_processor/processor/locking/locks.clj
@@ -7,37 +7,52 @@
   [database lock-id & body]
   `(let [db# (:handle ~database)
          datasource# (:datasource db#)
-         connection# (.getConnection datasource#)]
-     (try
-       (log/log-debug
-         {:lock-id ~lock-id}
-         "Acquiring lock")
-       (let [get-lock-statement#
-             (.prepareStatement
-               connection#
-               "SELECT pg_try_advisory_lock(?)")
+         release-lock# (fn [connection#]
+                         (let [release-lock-statement#
+                               (.prepareStatement
+                                 connection#
+                                 "SELECT pg_advisory_unlock(?)")]
+                           (.setInt release-lock-statement# 1 ~lock-id)
+                           (.execute release-lock-statement#)
+                           nil))]
+     (when-let [connection# (try
+                              (.getConnection datasource#)
+                              (catch Exception e#
+                                (log/log-warn
+                                  {:lock-id   ~lock-id
+                                   :exception e#}
+                                  "Failed to secure the connection object")
+                                nil))]
+       (try
+         (log/log-debug
+           {:lock-id ~lock-id}
+           "Acquiring lock")
+         (let [get-lock-statement#
+               (.prepareStatement
+                 connection#
+                 "SELECT pg_try_advisory_lock(?)")
 
-             _# (.setInt get-lock-statement# 1 ~lock-id)
-             result-set# (.executeQuery get-lock-statement#)
+               _# (.setInt get-lock-statement# 1 ~lock-id)
+               result-set# (.executeQuery get-lock-statement#)
 
-             _# (.first result-set#)
-             acquired# (.getBoolean result-set# 1)
+               _# (.first result-set#)
+               acquired# (.getBoolean result-set# 1)
 
-             _# (.close result-set#)]
+               _# (.close result-set#)]
 
-         (when acquired#
-           ~@body))
+           (when acquired#
+             (log/log-debug
+               {:lock-id ~lock-id}
+               "Lock acquired")
+             ~@body
+             (log/log-debug
+               {:lock-id ~lock-id}
+               "Releasing lock")
+             (release-lock# connection#)))
 
-       (finally
-         (do
-           (log/log-debug
-             {:lock-id ~lock-id}
-             "Releasing lock")
-           (let [release-lock-statement#
-                 (.prepareStatement
-                   connection#
-                   "SELECT pg_advisory_unlock(?)")]
-             (doto
-               release-lock-statement#
-               (.setInt 1 ~lock-id)
-               .execute)))))))
+         (catch Exception e#
+           (log/log-warn
+             {:lock-id   ~lock-id
+              :exception e#}
+             "Failed run the acquire lock method")
+           (release-lock# connection#))))))

--- a/src/event_processor/processor/locking/locks.clj
+++ b/src/event_processor/processor/locking/locks.clj
@@ -14,6 +14,7 @@
                                  "SELECT pg_advisory_unlock(?)")]
                            (.setInt release-lock-statement# 1 ~lock-id)
                            (.execute release-lock-statement#)
+                           (.close connection#)
                            nil))]
      (when-let [connection# (try
                               (.getConnection datasource#)

--- a/src/event_processor/processor/locking/locks.clj
+++ b/src/event_processor/processor/locking/locks.clj
@@ -16,16 +16,18 @@
              (.prepareStatement
                connection#
                "SELECT pg_try_advisory_lock(?)")
-             result-set# (doto
-                          get-lock-statement#
-                          (.setInt 1 ~lock-id)
-                          .executeQuery)
-             acquired# (doto
-                         result-set#
-                         .first
-                         (.getBoolean 1))]
+
+             _# (.setInt get-lock-statement# 1 ~lock-id)
+             result-set# (.executeQuery get-lock-statement#)
+
+             _# (.first result-set#)
+             acquired# (.getBoolean result-set# 1)
+
+             _# (.close result-set#)]
+
          (when acquired#
            ~@body))
+
        (finally
          (do
            (log/log-debug

--- a/src/event_processor/processor/locking/locks.clj
+++ b/src/event_processor/processor/locking/locks.clj
@@ -2,8 +2,8 @@
   (:require [event-processor.utils.logging :as log]))
 
 (defmacro with-lock
-  "Acquire an advisory lock on the database, and run function, then release the lock.
-   Block if lock is taken."
+  "Try to acquire a Postgres advisory lock on the database.
+  If successful, run `body`, otherwise skip."
   [database lock-id & body]
   `(let [db# (:handle ~database)
          datasource# (:datasource db#)

--- a/src/event_processor/processor/locking/locks.clj
+++ b/src/event_processor/processor/locking/locks.clj
@@ -1,28 +1,41 @@
 (ns event-processor.processor.locking.locks
-  (:require [hugsql.core :as hugsql]
-            [event-processor.utils.logging :as log]))
-
-(declare get-lock release-lock)
-(hugsql/def-db-fns "event_processor/processor/locking/locks.sql")
+  (:require [event-processor.utils.logging :as log]))
 
 (defmacro with-lock
   "Acquire an advisory lock on the database, and run function, then release the lock.
    Block if lock is taken."
   [database lock-id & body]
-  `(try
-     (log/log-debug
-       {:lock-id ~lock-id}
-       "Acquiring lock")
+  `(let [db# (:handle ~database)
+         datasource# (:datasource db#)
+         connection# (.getConnection datasource#)]
      (try
-       (get-lock (:handle ~database) {:lock_id ~lock-id})
-       (catch Exception exception#
-         (throw (ex-info "Error getting locks"
-                  {:lock_id ~lock-id :lock-error true}
-                  exception#))))
-     ~@body
-     (finally
-       (do
-         (log/log-debug
-           {:lock-id ~lock-id}
-           "Releasing lock")
-         (release-lock (:handle ~database) {:lock_id ~lock-id})))))
+       (log/log-debug
+         {:lock-id ~lock-id}
+         "Acquiring lock")
+       (let [get-lock-statement#
+             (.prepareStatement
+               connection#
+               "SELECT pg_try_advisory_lock(?)")
+             result-set# (doto
+                          get-lock-statement#
+                          (.setInt 1 ~lock-id)
+                          .executeQuery)
+             acquired# (doto
+                         result-set#
+                         .first
+                         (.getBoolean 1))]
+         (when acquired#
+           ~@body))
+       (finally
+         (do
+           (log/log-debug
+             {:lock-id ~lock-id}
+             "Releasing lock")
+           (let [release-lock-statement#
+                 (.prepareStatement
+                   connection#
+                   "SELECT pg_advisory_unlock(?)")]
+             (doto
+               release-lock-statement#
+               (.setInt 1 ~lock-id)
+               .execute)))))))

--- a/src/event_processor/processor/locking/locks.sql
+++ b/src/event_processor/processor/locking/locks.sql
@@ -1,5 +1,0 @@
--- :name get-lock :? :1
-SELECT pg_advisory_lock(:lock_id);
-
--- :name release-lock :? :1
-select pg_advisory_unlock(:lock_id);

--- a/test/event_processor/locking_test.clj
+++ b/test/event_processor/locking_test.clj
@@ -59,51 +59,6 @@
                             (map get-event-handler
                               (spy/calls mock-on-processing-complete))))))))))
 
-  (deftest second-system-should-run-processor-if-first-errors
-    (let [event {:message   "event"
-                 :group-key "group-key"}
-          unprocessed-events (atom [event])
-
-          remove-unprocessed-event (fn [completed] (reset! unprocessed-events
-                                                     (remove #(= % completed) @unprocessed-events)))
-
-          captured-handler (atom nil)
-
-          mock-get-unprocessed-events (spy/mock (fn [actual-event-handler _]
-                                                  (if @captured-handler
-                                                    @unprocessed-events
-                                                    (do
-                                                      (reset! captured-handler actual-event-handler)
-                                                      (throw Exception)))))
-          mock-group-unprocessed-events-by (spy/mock (fn [_ _ event] (:group-key event)))
-          mock-handle-event (spy/spy)
-          mock-on-processing-complete
-          (spy/mock (fn [_ _ event _] (remove-unprocessed-event event)))]
-
-      (with-redefs [stub-get-unprocessed-events mock-get-unprocessed-events
-                    stub-group-unprocessed-events-by mock-group-unprocessed-events-by
-                    stub-handle-event mock-handle-event
-                    stub-on-processing-complete mock-on-processing-complete]
-
-        (do-until
-          #(spy/called-once? mock-on-processing-complete)
-          {:matcher true?
-           :timeout 10000})
-
-        (testing "get-unprocessed-events called from both handlers"
-          (is (= 2 (count (unique-entries
-                            (map get-event-handler
-                              (spy/calls stub-get-unprocessed-events)))))))
-
-        (testing "other processing only called from one event handler"
-          (is (= 1 (count (unique-entries
-                            (map get-event-handler
-                              (spy/calls mock-group-unprocessed-events-by))
-                            (map get-event-handler
-                              (spy/calls mock-handle-event))
-                            (map get-event-handler
-                              (spy/calls mock-on-processing-complete))))))))))
-
   (deftest systems-with-different-lock-ids-run-independently
     (let [test-system-3 (atom (new-test-system (assoc database
                                                  :db-lock-id 987654)))


### PR DESCRIPTION
The Postgres locking mechanism requires the same connection to be used for locking and unlocking.
We changed the locking to use the `try` version, so that it doesn't block the operation and consume too many connections.